### PR TITLE
Changed import from "merge-images" to "merge-images-v2" in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ Which will look like this:
 Usage in Node.js is the same, however you'll need to also require [node-canvas](https://github.com/Automattic/node-canvas) and pass it in via the options object.
 
 ```js
-const mergeImages = require('merge-images');
-const Canvas = require('canvas');
+import mergeImages from 'merge-images-v2';
+import Canvas from 'canvas';
 
 mergeImages(['./body.png', './eyes.png', './mouth.png'], {
   Canvas: Canvas


### PR DESCRIPTION
In the README.md (which is also visible on NPM), you forgot to change the imports of some documentation examples from "merge-images" to "merge-images-v2".